### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,7 @@
 name: Release
+permissions:
+  contents: read
+  packages: write
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/mariusbreivik/netatmo/security/code-scanning/5](https://github.com/mariusbreivik/netatmo/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the steps in the workflow:
- The `contents: read` permission is required for the `Checkout` step.
- The `contents: read` and `packages: write` permissions are likely required for the `Run GoReleaser` step, as it may publish packages or releases.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as there is only one job (`release`) in this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
