### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,9 @@
 #
 name: "CodeQL"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/mariusbreivik/netatmo/security/code-scanning/2](https://github.com/mariusbreivik/netatmo/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow primarily performs code analysis, it likely only needs read access to the repository contents. We will add the following permissions block at the root level of the workflow:

```yaml
permissions:
  contents: read
```

This ensures that the workflow has only read access to the repository contents, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
